### PR TITLE
Allow sending messages on the local/loopback interface

### DIFF
--- a/imcpy/actors/base.py
+++ b/imcpy/actors/base.py
@@ -333,7 +333,7 @@ class IMCBase:
         if self._backseat_server is not None and self._loop is not None:
             asyncio.ensure_future(self._backseat_server.write_message(msg), loop=self._loop)
 
-    def send(self, node_id, msg, set_timestamp=True):
+    def send(self, node_id, msg, set_timestamp=True, ignore_local=True):
         """
         Send an imc message to the specified imc node. The node can be specified through it's imc address, system name
         or a tuple of both. If either of the first two does not uniquely specify a node an AmbiguousNode exception is
@@ -350,7 +350,7 @@ class IMCBase:
             msg.set_timestamp_now()
 
         node = self.resolve_node_id(node_id)
-        node.send(msg, log_fh=self.log_imc_fh)
+        node.send(msg, log_fh=self.log_imc_fh, ignore_local=ignore_local)
 
         # Send to static destinations
         self.send_static(msg)

--- a/imcpy/actors/base.py
+++ b/imcpy/actors/base.py
@@ -68,7 +68,7 @@ class IMCBase:
         self._task_mc: Optional[asyncio.Task] = None
         self._task_imc: Optional[asyncio.Task] = None
         self._task_server: Optional[asyncio.Task] = None
-        self._server_backseat: Optional[IMCProtocolTCPServer] = None
+        self._backseat_server: Optional[IMCProtocolTCPServer] = None
         self._subs: Dict[Type[imcpy.Message], List[types.MethodType]] = {}
 
         # IMC/Multicast ports (assigned when socket is created)

--- a/imcpy/node.py
+++ b/imcpy/node.py
@@ -135,7 +135,7 @@ class IMCNode:
     def update_entity_id(self, ent_id, ent_label):
         self.entities[ent_label] = ent_id
 
-    def send(self, msg, log_fh=None):
+    def send(self, msg, log_fh=None, ignore_local=True):
         """
         Sends the IMC message to the node, filling in the destination
         :param msg: The IMC message to send
@@ -157,7 +157,7 @@ class IMCNode:
         # Note: this might not account for funky ip routing
         networks = [
             ip.IPv4Network((addr, mask), strict=False)
-            for name, addr, mask in get_interfaces(ignore_local=True, only_ipv4=True)
+            for name, addr, mask in get_interfaces(ignore_local=ignore_local, only_ipv4=True)
         ]
         for svc in imcudp_services:
             svc_ip = ip.ip_address(svc.ip)


### PR DESCRIPTION
Use case: debugging with dune running on local machine in Simulation profile.

While working on this I also noticed a typo in the initialization of _backseat_server (it was called _server_backseat)

Tested against DUNE running in simulation